### PR TITLE
Use PSR12 / PER and fix short closure issue

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -22,7 +22,7 @@ final class Config extends CsFixerConfig
     public function getRules(): array
     {
         $out = [
-            '@PER' => true,
+            '@PSR12' => true,
             '@Symfony' => true,
             '@PHP70Migration' => true,
             '@PHP70Migration:risky' => $this->useRisky,
@@ -91,9 +91,8 @@ final class Config extends CsFixerConfig
             'list_syntax' => ['syntax' => 'short'],
             
             // TODO Remove when https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6970 is merged
-            'function_declaration' => [
-                'closure_fn_spacing' => 'none'
-            ],
+            // but settings as false as upgrade to 3.11 is not easy (need upgrade doctrine/anotation and synfony/console). So let prettier do the formatting job
+            'function_declaration' => false,
         ];
 
         if (version_compare(PHP_VERSION, '7.1.0', '<')) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -22,7 +22,7 @@ final class Config extends CsFixerConfig
     public function getRules(): array
     {
         $out = [
-            '@PSR2' => true,
+            '@PER' => true,
             '@Symfony' => true,
             '@PHP70Migration' => true,
             '@PHP70Migration:risky' => $this->useRisky,
@@ -89,6 +89,11 @@ final class Config extends CsFixerConfig
             // List (array destructuring) assignment should be declared using the configured syntax.
             // https://cs.symfony.com/doc/rules/list_notation/list_syntax.html
             'list_syntax' => ['syntax' => 'short'],
+            
+            // TODO Remove when https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6970 is merged
+            'function_declaration' => [
+                'closure_fn_spacing' => 'none'
+            ],
         ];
 
         if (version_compare(PHP_VERSION, '7.1.0', '<')) {


### PR DESCRIPTION
### Comportement actuel

On n'utilise la (vieille) PSR-2.
Il y a un conflit entre php-cs-fixer et prettier, et c'est php-cs-fixer qui n'est pas à jour d'après la [PER sur les short closure](https://www.php-fig.org/per/coding-style/#71-short-closures)

### Nouveau comportement

On migre vers PSR-12 + on applique le fix sur les short closure le temps que la PR soit mergée dans php-cs-fixer