### PR TITLE
Prefer prettier over Symfony style

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -93,7 +93,7 @@ final class Config extends CsFixerConfig
             // List (array destructuring) assignment should be declared using the configured syntax.
             // https://cs.symfony.com/doc/rules/list_notation/list_syntax.html
             'list_syntax' => ['syntax' => 'short'],
-            
+
             // Replace non multibyte-safe functions with corresponding mb function.
             // https://cs.symfony.com/doc/rules/alias/mb_str_functions.html
             'mb_str_functions' => $this->useRisky,
@@ -120,7 +120,26 @@ final class Config extends CsFixerConfig
                 // 'allow_hidden_params' => true, // TODO activate this when available
                 'remove_inheritdoc' => true,
                 'allow_mixed' => true,
-        ],
+            ],
+
+            // Operators - when multiline - must always be at the beginning or at the end of the line.
+            // Not explicitly set in PER, use the prettier version instead of Symfony's one
+            // https://cs.symfony.com/doc/rules/operator/operator_linebreak.html
+            'operator_linebreak' => [
+                'only_booleans' => true,
+                'position' => 'end',
+            ],
+
+            // Ensures a single space after language constructs.
+            // Comparing to Symfony let prettier handle `as` like it wants
+            // https://cs.symfony.com/doc/rules/language_construct/single_space_around_construct.html
+            'single_space_around_construct' => [
+                'constructs_preceded_by_a_single_space' => ['use_lambda']
+
+            ],
+
+            // until prettier fixes https://github.com/prettier/plugin-php/issues/2400
+            'single_line_empty_body' => false,
 
             // === Doctrine ===
 
@@ -159,4 +178,3 @@ final class Config extends CsFixerConfig
         return $out;
     }
 }
-

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -48,6 +48,6 @@ class ConfigTest extends TestCase
         $symfonyPosition = array_search('@Symfony', array_keys($rules));
         $this->assertEquals(0, $symfonyPosition);
         $visiPosition = array_search('visibility_required', array_keys($rules));
-        $this->assertEquals(29, $visiPosition);
+        $this->assertEquals(32, $visiPosition);
     }
 }


### PR DESCRIPTION
Actuellement on a un conflit entre prettier et php-cs-fixer (en particulier avec la définition de Symfony), et on se retrouve souvent avec des diffs comme ça
![image](https://github.com/user-attachments/assets/e09feea3-6cc0-4aa5-9d57-113c7e613536)

et comme ça :
![image](https://github.com/user-attachments/assets/c75cb0de-4488-47b7-8c11-d5bb07c3adef)

Dès qu'on enregistre un fichier et qu'on passe prettier dessus.

Pour le premier screen, le soucis vient d'un problème de prettier : https://github.com/prettier/plugin-php/issues/2400

Pour le second, c'est que prettier est opiniatre, et que la PER n'impose rien dans ce sens, donc ils se rangent du côté de prettier JS pour faire le formatage.

Perso je préfère les `&&` en début de ligne, mais je trouve le soucis de cohérence bien plus embêtant, donc je me range du côté de prettier.
