### PR TITLE
Fix another conflicts with prettier

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -177,6 +177,10 @@ final class Config extends CsFixerConfig
                 'types_spaces' => false, // not that clear in PER
                 'single_space_around_construct' => false,
                 'method_argument_space' => false,
+                'integer_literal_case' => false,
+                'heredoc_indentation' => [
+                    'indentation' => 'same_as_start',
+                ],
             ]);
         }
 


### PR DESCRIPTION
### integer_literal_case
prettier [does format `0xFF` → `0xff`](https://loilo.github.io/prettier-php-playground/#N4IgDgTgpgLjCWUIHkwIPYDsDOIBcok8mMA6vACYwAW+AHAAwA0IMAhgEblW14AsLAK7YoAFU648AMzYAbES2zEA5rKgBFQehhR8M+VBZhqYAGpIlWfCACsAOj4gWMCG3iyVAYXQBbH2wAFAAkA-BdBQxAOVwBjKABlGABPNWswJABaGNwWaABHQXhoANdlfz05BRBiEQgYErYytgqDAF8WKAp4GHQUNHgsSVA2bBgWkXbqzDBBMbwQAB4AfmMwAB1MABI2AAIAXh2GAA8AMROAbhBWoA), but php-cs-fixer [does the opposite](https://cs.symfony.com/doc/rules/casing/integer_literal_case.html)

Disable the php-cs-fixer rule

### heredoc_indentation

prettier does keep the same column for heredoc end of comment.